### PR TITLE
feat: move to gatsby-plugin-image

### DIFF
--- a/examples/starter-data-nostyles/src/components/archive/PostsList.js
+++ b/examples/starter-data-nostyles/src/components/archive/PostsList.js
@@ -3,8 +3,13 @@ import { PostEntry } from '../post'
 
 export const PostsList = ({ posts, ...props }) => (
   <div className="posts-list" {...props}>
-    {posts.map((post) => (
-      <PostEntry key={post.id} location="archive" post={post} />
+    {posts.map((post, index) => (
+      <PostEntry
+        key={post.id}
+        location="archive"
+        post={post}
+        isFirst={index === 0}
+      />
     ))}
   </div>
 )

--- a/examples/starter-data-nostyles/src/components/templates/Post.js
+++ b/examples/starter-data-nostyles/src/components/templates/Post.js
@@ -40,7 +40,7 @@ const Post = ({ post, ctx }) => {
       />
       <div className="mainContainer">
         <div>
-          <PostEntry post={post} location="single" ctx={ctx} />
+          <PostEntry post={post} location="single" ctx={ctx} isFirst={true} />
           {sidebarPage && <Sidebar widgets={sidebarWidgets} />}
         </div>
         {addWordPressComments && post.commentStatus === 'open' && (

--- a/examples/starter-developer/src/components/archive/PostsList.js
+++ b/examples/starter-developer/src/components/archive/PostsList.js
@@ -3,8 +3,13 @@ import { PostEntry } from 'starterComponents'
 
 export const PostsList = ({ posts, ...props }) => (
   <div className="posts-list" {...props}>
-    {posts.map((post) => (
-      <PostEntry key={post.id} location="archive" post={post} />
+    {posts.map((post, index) => (
+      <PostEntry
+        key={post.id}
+        location="archive"
+        post={post}
+        isFirst={index === 0}
+      />
     ))}
   </div>
 )

--- a/examples/starter-developer/src/components/templates/Post.js
+++ b/examples/starter-developer/src/components/templates/Post.js
@@ -43,7 +43,7 @@ const Post = ({ post, ctx }) => {
             alignItems: `flex-start`,
           }}
         >
-          <PostEntry post={post} location="single" ctx={ctx} />
+          <PostEntry post={post} location="single" ctx={ctx} isFirst={true} />
           {sidebarPage && <Sidebar widgets={sidebarWidgets} />}
         </Flex>
         <Comments post={post} />

--- a/packages/gatsby-theme-wp-bootstrap5/gatsby-config.js
+++ b/packages/gatsby-theme-wp-bootstrap5/gatsby-config.js
@@ -66,6 +66,9 @@ module.exports = (options) => {
         ...(options.lightboxOptions || {}),
       },
     },
+    {
+      resolve: 'gatsby-plugin-image',
+    },
   ]
   /**
    * Conditionally add google fonts plugin

--- a/packages/gatsby-theme-wp-bootstrap5/package.json
+++ b/packages/gatsby-theme-wp-bootstrap5/package.json
@@ -24,7 +24,7 @@
     "bootstrap": "^5.0.0-alpha3",
     "date-fns": "^2.16.1",
     "gatsby-image": "^2.7.0",
-    "gatsby-plugin-google-fonts": "^1.0.1",
+    "gatsby-plugin-image": "^0.5.1",
     "gatsby-plugin-mailchimp": "^5.2.2",
     "gatsby-plugin-react-helmet": "^3.6.0",
     "gatsby-plugin-root-import": "^2.0.5",

--- a/packages/gatsby-theme-wp-bootstrap5/src/@gatsbywpthemes/gatsby-theme-blog-data/templates/posts-query.js
+++ b/packages/gatsby-theme-wp-bootstrap5/src/@gatsbywpthemes/gatsby-theme-blog-data/templates/posts-query.js
@@ -8,22 +8,25 @@ export const pageQuery = graphql`
     altText
     localFile {
       childImageSharp {
-        fluid(maxWidth: 1200, quality: 80) {
-          ...GatsbyImageSharpFluid_withWebp
-        }
+        gatsbyImageData(maxWidth: 1200, quality: 80, layout: CONSTRAINED)
       }
     }
   }
+
   fragment GatsbyImageQueryArchive on WpMediaItem {
     altText
     localFile {
       childImageSharp {
-        fluid(maxWidth: 306, maxHeight: 200, quality: 60) {
-          ...GatsbyImageSharpFluid_withWebp
-        }
+        gatsbyImageData(
+          maxWidth: 306
+          maxHeight: 200
+          quality: 60
+          layout: FLUID
+        )
       }
     }
   }
+
   fragment PostTemplateFragmentArchive on WpPost {
     id
     uri

--- a/packages/gatsby-theme-wp-bootstrap5/src/components/archive/ArchiveContent.js
+++ b/packages/gatsby-theme-wp-bootstrap5/src/components/archive/ArchiveContent.js
@@ -18,8 +18,8 @@ export const ArchiveContent = ({
           <div className="col-md-6 col-lg-9">
             <div className="row">
               {posts.nodes &&
-                posts.nodes.map((post) => (
-                  <PostEntry key={post.id} post={post} />
+                posts.nodes.map((post, index) => (
+                  <PostEntry key={post.id} post={post} isFirst={index === 0} />
                 ))}
             </div>
             <Pagination ctx={ctx} />

--- a/packages/gatsby-theme-wp-bootstrap5/src/components/images/Image.js
+++ b/packages/gatsby-theme-wp-bootstrap5/src/components/images/Image.js
@@ -1,10 +1,14 @@
 import React from 'react'
-import Img from 'gatsby-image'
+import { GatsbyImage } from 'gatsby-plugin-image'
 
-export const Image = ({ img }) => {
+export const Image = ({ img, loading = 'lazy' }) => {
   return (
     !!img && (
-      <Img fluid={img.node.localFile.childImageSharp.fluid} alt={img.altText} />
+      <GatsbyImage
+        loading={loading}
+        image={img.node.localFile.childImageSharp.gatsbyImageData}
+        alt={img.altText}
+      />
     )
   )
 }

--- a/packages/gatsby-theme-wp-bootstrap5/src/components/post/PostEntry.js
+++ b/packages/gatsby-theme-wp-bootstrap5/src/components/post/PostEntry.js
@@ -7,7 +7,12 @@ import {
   Tags,
 } from './index'
 
-export const PostEntry = ({ ctx, post, location = 'archive' }) => {
+export const PostEntry = ({
+  ctx,
+  post,
+  isFirst = false,
+  location = 'archive',
+}) => {
   return (
     <article
       className="entry col-lg-4 mb-4"
@@ -16,7 +21,11 @@ export const PostEntry = ({ ctx, post, location = 'archive' }) => {
       data-sal-easing="ease"
     >
       <div className="shadow h-100 d-flex flex-column">
-        <PostEntryMedia post={post} location={location} />
+        <PostEntryMedia
+          post={post}
+          location={location}
+          imageLoading={isFirst ? 'eager' : 'lazy'}
+        />
         <PostEntryIntro ctx={ctx} post={post} location={location} />
         {location === 'single' && (
           <>

--- a/packages/gatsby-theme-wp-bootstrap5/src/components/post/PostEntryFull.js
+++ b/packages/gatsby-theme-wp-bootstrap5/src/components/post/PostEntryFull.js
@@ -36,7 +36,7 @@ export const PostEntryFull = ({ ctx, post }) => {
           title={post.title}
           media={
             post.featuredImage
-              ? post.featuredImage.node.localFile.childImageSharp.fluid.src
+              ? post.featuredImage.node.localFile.childImageSharp.gatsbyImageData.src
               : null
           }
         />
@@ -50,5 +50,5 @@ export const PostEntryFull = ({ ctx, post }) => {
       </div>
       <Sidebar />
     </article>
-  )
+  );
 }

--- a/packages/gatsby-theme-wp-bootstrap5/src/components/post/PostEntryMedia.js
+++ b/packages/gatsby-theme-wp-bootstrap5/src/components/post/PostEntryMedia.js
@@ -12,6 +12,7 @@ const WithLink = ({ uri, children, location }) =>
   )
 
 export const PostEntryMedia = ({
+  imageLoading = 'lazy',
   post: { featuredImage, uri },
   location = 'archive',
 }) => {
@@ -19,7 +20,7 @@ export const PostEntryMedia = ({
     <>
       {!!featuredImage && (
         <WithLink location={location} uri={uri}>
-          <Image img={featuredImage} />
+          <Image img={featuredImage} loading={imageLoading} />
         </WithLink>
       )}
     </>

--- a/packages/gatsby-theme-wp-bootstrap5/src/components/templates/Post.js
+++ b/packages/gatsby-theme-wp-bootstrap5/src/components/templates/Post.js
@@ -5,7 +5,7 @@ import { Seo } from '@gatsbywpthemes/gatsby-plugin-wp-seo'
 
 const Post = (props) => {
   const { post, ctx } = props
-  const featuredImage = post.featuredImage?.node.localFile.childImageSharp.fluid
+  const featuredImage = post.featuredImage?.node.localFile.childImageSharp?.gatsbyImageData
   return (
     <Layout>
       <Seo

--- a/packages/gatsby-theme-wp-bootstrap5/src/components/widgets/RecentPosts.js
+++ b/packages/gatsby-theme-wp-bootstrap5/src/components/widgets/RecentPosts.js
@@ -1,83 +1,75 @@
 import React from 'react'
 import { Link, useStaticQuery, graphql } from 'gatsby'
 import { format } from 'date-fns'
-import Img from 'gatsby-image'
+import { GatsbyImage } from "gatsby-plugin-image";
 import { WidgetContainer } from './index'
 
-const RECENT_POSTS_QUERY = graphql`
-  query GetRecentPosts {
-    allWpPost(limit: 5, sort: { order: DESC, fields: date }) {
-      nodes {
-        id
-        title
-        uri
-        date
-        featuredImage {
-          node {
-            altText
-            localFile {
-              childImageSharp {
-                fixed(width: 72, height: 48, quality: 80) {
-                  ...GatsbyImageSharpFixed
-                }
-              }
+const RECENT_POSTS_QUERY = graphql`query GetRecentPosts {
+  allWpPost(limit: 5, sort: {order: DESC, fields: date}) {
+    nodes {
+      id
+      title
+      uri
+      date
+      featuredImage {
+        node {
+          altText
+          localFile {
+            childImageSharp {
+              gatsbyImageData(width: 72, height: 48, quality: 80, layout: FIXED)
             }
           }
         }
       }
     }
   }
+}
 `
 
 export const RecentPosts = () => {
   const data = useStaticQuery(RECENT_POSTS_QUERY)
   const { nodes } = data.allWpPost
-  return (
-    !!nodes.length && (
-      <WidgetContainer className="widget-recent-posts">
-        <h2 className="widget-title h4">Recent Posts</h2>
-        <ul className="list-group list-group-flush">
-          {nodes.map((post) => {
-            return (
-              <li
-                className="list-group-item bg-transparent d-flex align-items-center px-0"
-                key={post.id}
+  return !!nodes.length && (
+    <WidgetContainer className="widget-recent-posts">
+      <h2 className="widget-title h4">Recent Posts</h2>
+      <ul className="list-group list-group-flush">
+        {nodes.map((post) => {
+          return (
+            <li
+              className="list-group-item bg-transparent d-flex align-items-center px-0"
+              key={post.id}
+            >
+              <Link
+                className="me-3"
+                aria-label={`Read more - ${post.title}`}
+                to={post.uri}
               >
+                {post.featuredImage && (
+                  <GatsbyImage
+                    image={post.featuredImage.node.localFile.childImageSharp.gatsbyImageData}
+                    alt={post.featuredImage.node.altText} />
+                )}
+              </Link>
+              <small className="textual">
                 <Link
-                  className="me-3"
-                  aria-label={`Read more - ${post.title}`}
+                  className="widget-post-date text-decoration-none text-reset"
                   to={post.uri}
                 >
-                  {post.featuredImage && (
-                    <Img
-                      alt={post.featuredImage.node.altText}
-                      fixed={
-                        post.featuredImage.node.localFile.childImageSharp.fixed
-                      }
-                    />
-                  )}
+                  <time className="entry-date" dateTime={post.date}>
+                    {format(new Date(post.date), 'MMMM dd, yyyy')}
+                  </time>
                 </Link>
-                <small className="textual">
-                  <Link
-                    className="widget-post-date text-decoration-none text-reset"
-                    to={post.uri}
-                  >
-                    <time className="entry-date" dateTime={post.date}>
-                      {format(new Date(post.date), 'MMMM dd, yyyy')}
-                    </time>
-                  </Link>
-                  <br />
-                  <Link
-                    className="widget-post-title heading-font text-decoration-none text-reset"
-                    to={post.uri}
-                    dangerouslySetInnerHTML={{ __html: post.title }}
-                  />
-                </small>
-              </li>
-            )
-          })}
-        </ul>
-      </WidgetContainer>
-    )
-  )
+                <br />
+                <Link
+                  className="widget-post-title heading-font text-decoration-none text-reset"
+                  to={post.uri}
+                  dangerouslySetInnerHTML={{ __html: post.title }}
+                />
+              </small>
+            </li>
+          );
+        })}
+      </ul>
+    </WidgetContainer>
+  );
 }

--- a/packages/gatsby-theme-wp-ginger-chakra/src/components/archive/ArchiveContent.js
+++ b/packages/gatsby-theme-wp-ginger-chakra/src/components/archive/ArchiveContent.js
@@ -7,7 +7,9 @@ export const ArchiveContent = ({ posts, ctx, name, text = 'Posts from: ' }) => {
       <section>
         {name && <ArchiveTitle text={text} name={name} />}
         {posts.nodes &&
-          posts.nodes.map((post) => <PostEntry key={post.id} post={post} />)}
+          posts.nodes.map((post, index) => (
+            <PostEntry key={post.id} post={post} isFirst={index === 0} />
+          ))}
       </section>
       <Pagination ctx={ctx} />
     </>

--- a/packages/gatsby-theme-wp-starter/src/components/archive/PostsList.js
+++ b/packages/gatsby-theme-wp-starter/src/components/archive/PostsList.js
@@ -3,8 +3,13 @@ import { PostEntry } from 'starterComponents'
 
 export const PostsList = ({ posts, ...props }) => (
   <div className="posts-list" {...props}>
-    {posts.map((post) => (
-      <PostEntry key={post.id} location="archive" post={post} />
+    {posts.map((post, index) => (
+      <PostEntry
+        key={post.id}
+        location="archive"
+        post={post}
+        isFirst={index === 0}
+      />
     ))}
   </div>
 )

--- a/packages/gatsby-theme-wp-starter/src/components/templates/Post.js
+++ b/packages/gatsby-theme-wp-starter/src/components/templates/Post.js
@@ -43,7 +43,7 @@ const Post = ({ post, ctx }) => {
             alignItems: `flex-start`,
           }}
         >
-          <PostEntry post={post} location="single" ctx={ctx} />
+          <PostEntry post={post} location="single" ctx={ctx} isFirst={true} />
           {sidebarPage && <Sidebar widgets={sidebarWidgets} />}
         </Flex>
         <Comments post={post} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -5225,6 +5225,11 @@ babel-eslint@^10.1.0:
     eslint-visitor-keys "^1.0.0"
     resolve "^1.12.0"
 
+babel-jsx-utils@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/babel-jsx-utils/-/babel-jsx-utils-1.0.1.tgz#f2d171cba526594e7d69e9893d634502cf950f07"
+  integrity sha512-Qph/atlQiSvfmkoIZ9VA+t8dA0ex2TwL37rkhLT9YLJdhaTMZ2HSM2QGzbqjLWanKA+I3wRQJjjhtuIEgesuLw==
+
 babel-loader@^8.1.0:
   version "8.2.2"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.2.2.tgz#9363ce84c10c9a40e6c753748e1441b60c8a0b81"
@@ -9651,6 +9656,21 @@ gatsby-plugin-google-tagmanager@^2.8.0:
   integrity sha512-Te4SWBKLFjppYf0sIOkdlRerq25relPL8v/8wN/PZwDHaxzSZ3PNEO9n9QjPr+MeztljEZVdWi6LKniyIT8T9Q==
   dependencies:
     "@babel/runtime" "^7.12.5"
+
+gatsby-plugin-image@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-image/-/gatsby-plugin-image-0.5.1.tgz#90c743afd333095a9078d6487c22d29057278a31"
+  integrity sha512-y/n0SXOLQvXQAVjZZK+RQcH9i2is9+qtfL6xzgQtba0WLGECdJ8bHY8xJBlSRtWLLoFVV906CmEJdWe7WqYIGA==
+  dependencies:
+    "@babel/parser" "^7.12.5"
+    "@babel/traverse" "^7.12.5"
+    babel-jsx-utils "^1.0.1"
+    babel-plugin-remove-graphql-queries "^2.14.0"
+    camelcase "^5.3.1"
+    chokidar "^3.4.3"
+    fs-extra "^8.1.0"
+    gatsby-core-utils "^1.8.0"
+    prop-types "^15.7.2"
 
 gatsby-plugin-mailchimp@^5.2.2:
   version "5.2.2"


### PR DESCRIPTION
I moved everything to the new `gatsby-plugin-image`. It improves Lighthouse scores significant, it's completely rewritten. I've also added `isFirst` to toggle loading to eager for the first image so it's downloaded quicker.

For more information or bugs please go to https://github.com/gatsbyjs/gatsby/discussions/27950