### PR TITLE
feat: lazyload more libs

### DIFF
--- a/examples/bootstrap5/src/@gatsbywpthemes/gatsby-theme-wp-bootstrap5/utils/ActivatePageScripts.js
+++ b/examples/bootstrap5/src/@gatsbywpthemes/gatsby-theme-wp-bootstrap5/utils/ActivatePageScripts.js
@@ -1,10 +1,11 @@
 import { useEffect } from "react"
-import Prism from "prismjs"
 
 export const ActivatePageScripts = () => {
   useEffect(() => {
-    // call the highlightAll() function to style our code blocks
-    Prism.highlightAll()
+    import(/* webpackChunkName: "prismjs" */ "prismjs").then((mod) => {
+      // call the highlightAll() function to style our code blocks
+      mod.default.highlightAll()
+    })
   }, [])
   return null
 }

--- a/examples/ginger-kitchen/src/@gatsbywpthemes/gatsby-theme-wp-ginger-chakra/utils/ActivatePageScripts.js
+++ b/examples/ginger-kitchen/src/@gatsbywpthemes/gatsby-theme-wp-ginger-chakra/utils/ActivatePageScripts.js
@@ -1,10 +1,11 @@
 import { useEffect } from "react"
-import Prism from "prismjs"
 
 export const ActivatePageScripts = () => {
   useEffect(() => {
-    // call the highlightAll() function to style our code blocks
-    Prism.highlightAll()
+    import(/* webpackChunkName: "prismjs" */ "prismjs").then((mod) => {
+      // call the highlightAll() function to style our code blocks
+      mod.default.highlightAll()
+    })
   }, [])
   return null
 }

--- a/examples/ginger-kitchen/src/@gatsbywpthemes/gatsby-theme-wp-ginger-chakra/utils/ActivatePostScripts.js
+++ b/examples/ginger-kitchen/src/@gatsbywpthemes/gatsby-theme-wp-ginger-chakra/utils/ActivatePostScripts.js
@@ -1,10 +1,11 @@
 import { useEffect } from "react"
-import Prism from "prismjs"
 
 export const ActivatePostScripts = () => {
   useEffect(() => {
-    // call the highlightAll() function to style our code blocks
-    Prism.highlightAll()
+    import(/* webpackChunkName: "prismjs" */ "prismjs").then((mod) => {
+      // call the highlightAll() function to style our code blocks
+      mod.default.highlightAll()
+    })
   }, [])
   return null
 }

--- a/examples/ginger-mini/src/@gatsbywpthemes/gatsby-theme-wp-ginger-chakra/utils/ActivatePageScripts.js
+++ b/examples/ginger-mini/src/@gatsbywpthemes/gatsby-theme-wp-ginger-chakra/utils/ActivatePageScripts.js
@@ -1,10 +1,11 @@
 import { useEffect } from "react"
-import Prism from "prismjs"
 
 export const ActivatePageScripts = () => {
   useEffect(() => {
-    // call the highlightAll() function to style our code blocks
-    Prism.highlightAll()
+    import(/* webpackChunkName: "prismjs" */ "prismjs").then((mod) => {
+      // call the highlightAll() function to style our code blocks
+      mod.default.highlightAll()
+    })
   }, [])
   return null
 }

--- a/examples/ginger-mini/src/@gatsbywpthemes/gatsby-theme-wp-ginger-chakra/utils/ActivatePostScripts.js
+++ b/examples/ginger-mini/src/@gatsbywpthemes/gatsby-theme-wp-ginger-chakra/utils/ActivatePostScripts.js
@@ -1,10 +1,11 @@
 import { useEffect } from "react"
-import Prism from "prismjs"
 
 export const ActivatePostScripts = () => {
   useEffect(() => {
-    // call the highlightAll() function to style our code blocks
-    Prism.highlightAll()
+    import(/* webpackChunkName: "prismjs" */ "prismjs").then((mod) => {
+      // call the highlightAll() function to style our code blocks
+      mod.default.highlightAll()
+    })
   }, [])
   return null
 }

--- a/examples/ginger-new/src/@gatsbywpthemes/gatsby-theme-wp-ginger-chakra/utils/ActivatePageScripts.js
+++ b/examples/ginger-new/src/@gatsbywpthemes/gatsby-theme-wp-ginger-chakra/utils/ActivatePageScripts.js
@@ -1,10 +1,11 @@
 import { useEffect } from "react"
-import Prism from "prismjs"
 
 export const ActivatePageScripts = () => {
   useEffect(() => {
-    // call the highlightAll() function to style our code blocks
-    Prism.highlightAll()
+    import(/* webpackChunkName: "prismjs" */ "prismjs").then((mod) => {
+      // call the highlightAll() function to style our code blocks
+      mod.default.highlightAll()
+    })
   }, [])
   return null
 }

--- a/examples/ginger-new/src/@gatsbywpthemes/gatsby-theme-wp-ginger-chakra/utils/ActivatePostScripts.js
+++ b/examples/ginger-new/src/@gatsbywpthemes/gatsby-theme-wp-ginger-chakra/utils/ActivatePostScripts.js
@@ -1,10 +1,11 @@
 import { useEffect } from "react"
-import Prism from "prismjs"
 
 export const ActivatePostScripts = () => {
   useEffect(() => {
-    // call the highlightAll() function to style our code blocks
-    Prism.highlightAll()
+    import(/* webpackChunkName: "prismjs" */ "prismjs").then((mod) => {
+      // call the highlightAll() function to style our code blocks
+      mod.default.highlightAll()
+    })
   }, [])
   return null
 }

--- a/examples/starter-data-nostyles/src/components/templates/Post.js
+++ b/examples/starter-data-nostyles/src/components/templates/Post.js
@@ -2,8 +2,25 @@ import React from 'react'
 import { Layout } from '../Layout'
 import { Seo } from '@gatsbywpthemes/gatsby-plugin-wp-seo'
 import { PostEntry, CommentsList, Sidebar } from '../index'
-import { DiscussionEmbed } from 'disqus-react'
 import { useThemeOptions } from '@gatsbywpthemes/gatsby-theme-blog-data/src/hooks'
+
+const DiscussionEmbed = React.lazy(() =>
+  import(/* webpackChunkName: "disqus-react" */ 'disqus-react').then(
+    (mod) => mod.DiscussionEmbed
+  )
+)
+
+const DisqusComments = (props) => {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  return (
+    <Suspense fallback={<></>}>
+      <DiscussionEmbed {...props} />
+    </Suspense>
+  )
+}
 
 const Post = ({ post, ctx }) => {
   const {
@@ -46,7 +63,7 @@ const Post = ({ post, ctx }) => {
         {addWordPressComments && post.commentStatus === 'open' && (
           <div>
             {disqus ? (
-              <DiscussionEmbed {...disqusConfig} />
+              <DisqusComments {...disqusConfig} />
             ) : (
               <CommentsList post={post} />
             )}

--- a/examples/starter-developer/src/components/comments/Comments.js
+++ b/examples/starter-developer/src/components/comments/Comments.js
@@ -1,16 +1,26 @@
-import React from 'react'
+import React, { Suspense } from 'react'
 import { useThemeOptions } from '@gatsbywpthemes/gatsby-theme-blog-data/src/hooks'
-import { WordPressComments, DisqusComments } from 'starterComponents'
+import { WordPressComments } from 'starterComponents'
+
+const DisqusComments = React.lazy(() =>
+  import(
+    /* webpackChunkName: "DisqusComments", webpackExports: ["DisqusComments"] */ 'bootstrap5ThemeComponents'
+  ).then((mod) => ({ default: mod.DisqusComments }))
+)
 
 export const Comments = ({ post }) => {
   const { addWordPressComments, disqus } = useThemeOptions()
 
+  if (typeof window === 'undefined') {
+    return null
+  }
+
   return (
-    <>
+    <Suspense fallback={<></>}>
       {!!addWordPressComments && post.commentStatus === 'open' && (
         <WordPressComments post={post} />
       )}
       {!!disqus && <DisqusComments disqus={disqus} post={post} />}
-    </>
+    </Suspense>
   )
 }

--- a/examples/starter-gradient/src/@gatsbywpthemes/gatsby-theme-wp-starter/utils/ActivatePageScripts.js
+++ b/examples/starter-gradient/src/@gatsbywpthemes/gatsby-theme-wp-starter/utils/ActivatePageScripts.js
@@ -1,10 +1,11 @@
 import { useEffect } from "react"
-import Prism from "prismjs"
 
 export const ActivatePageScripts = () => {
   useEffect(() => {
-    // call the highlightAll() function to style our code blocks
-    Prism.highlightAll()
+    import(/* webpackChunkName: "prismjs" */ "prismjs").then((mod) => {
+      // call the highlightAll() function to style our code blocks
+      mod.default.highlightAll()
+    })
   }, [])
   return null
 }

--- a/examples/starter-gradient/src/@gatsbywpthemes/gatsby-theme-wp-starter/utils/ActivatePostScripts.js
+++ b/examples/starter-gradient/src/@gatsbywpthemes/gatsby-theme-wp-starter/utils/ActivatePostScripts.js
@@ -1,10 +1,11 @@
 import { useEffect } from "react"
-import Prism from "prismjs"
 
 export const ActivatePostScripts = () => {
   useEffect(() => {
-    // call the highlightAll() function to style our code blocks
-    Prism.highlightAll()
+    import(/* webpackChunkName: "prismjs" */ "prismjs").then((mod) => {
+      // call the highlightAll() function to style our code blocks
+      mod.default.highlightAll()
+    })
   }, [])
   return null
 }

--- a/examples/starter-new/src/@gatsbywpthemes/gatsby-theme-wp-starter/utils/ActivatePageScripts.js
+++ b/examples/starter-new/src/@gatsbywpthemes/gatsby-theme-wp-starter/utils/ActivatePageScripts.js
@@ -1,10 +1,11 @@
 import { useEffect } from "react"
-import Prism from "prismjs"
 
 export const ActivatePageScripts = () => {
   useEffect(() => {
-    // call the highlightAll() function to style our code blocks
-    Prism.highlightAll()
+    import(/* webpackChunkName: "prismjs" */ "prismjs").then((mod) => {
+      // call the highlightAll() function to style our code blocks
+      mod.default.highlightAll()
+    })
   }, [])
   return null
 }

--- a/examples/starter-new/src/@gatsbywpthemes/gatsby-theme-wp-starter/utils/ActivatePostScripts.js
+++ b/examples/starter-new/src/@gatsbywpthemes/gatsby-theme-wp-starter/utils/ActivatePostScripts.js
@@ -1,10 +1,11 @@
 import { useEffect } from "react"
-import Prism from "prismjs"
 
 export const ActivatePostScripts = () => {
   useEffect(() => {
-    // call the highlightAll() function to style our code blocks
-    Prism.highlightAll()
+    import(/* webpackChunkName: "prismjs" */ "prismjs").then((mod) => {
+      // call the highlightAll() function to style our code blocks
+      mod.default.highlightAll()
+    })
   }, [])
   return null
 }

--- a/packages/gatsby-plugin-wordpress-lightbox/src/lightboxParserFunction.js
+++ b/packages/gatsby-plugin-wordpress-lightbox/src/lightboxParserFunction.js
@@ -1,7 +1,9 @@
 import React from "react"
 import { domToReact, attributesToProps } from "html-react-parser"
 
-const ClientSideOnlyLazy = React.lazy(() => import("./LightboxWrapper"))
+const ClientSideOnlyLazy = React.lazy(() =>
+  import(/* webpackChunkName: "LightboxWrapper" */ "./LightboxWrapper")
+)
 const findInnerA = (node) => {
   let value = null
   if (node && node.name === "a") {

--- a/packages/gatsby-theme-wp-bootstrap5/src/components/comments/Comments.js
+++ b/packages/gatsby-theme-wp-bootstrap5/src/components/comments/Comments.js
@@ -1,11 +1,22 @@
-import React from 'react'
+import React, { Suspense } from 'react'
 import { useThemeOptions } from '@gatsbywpthemes/gatsby-theme-blog-data/src/hooks'
-import { WordPressComments, DisqusComments } from 'bootstrap5ThemeComponents'
+import { WordPressComments } from 'bootstrap5ThemeComponents'
+
+const DisqusComments = React.lazy(() =>
+  import(
+    /* webpackChunkName: "DisqusComments", webpackExports: ["DisqusComments"] */ 'bootstrap5ThemeComponents'
+  ).then((mod) => ({ default: mod.DisqusComments }))
+)
 
 export const Comments = ({ post }) => {
   const { addWordPressComments, disqus } = useThemeOptions()
+
+  if (typeof window === 'undefined') {
+    return null
+  }
+
   return (
-    <>
+    <Suspense fallback={<></>}>
       {!!addWordPressComments && post.commentStatus === 'open' && (
         <WordPressComments post={post} />
       )}
@@ -14,6 +25,6 @@ export const Comments = ({ post }) => {
           <DisqusComments disqus={disqus} post={post} />
         </div>
       )}
-    </>
+    </Suspense>
   )
 }

--- a/packages/gatsby-theme-wp-ginger-chakra/src/components/comments/Comments.js
+++ b/packages/gatsby-theme-wp-ginger-chakra/src/components/comments/Comments.js
@@ -1,15 +1,26 @@
-import React from 'react'
+import React, { Suspense } from 'react'
 import { useThemeOptions } from '@gatsbywpthemes/gatsby-theme-blog-data/src/hooks'
-import { WordPressComments, DisqusComments } from 'gingerThemeComponents'
+import { WordPressComments } from 'gingerThemeComponents'
+
+const DisqusComments = React.lazy(() =>
+  import(
+    /* webpackChunkName: "DisqusComments", webpackExports: ["DisqusComments"] */ 'bootstrap5ThemeComponents'
+  ).then((mod) => ({ default: mod.DisqusComments }))
+)
 
 export const Comments = ({ post }) => {
   const { addWordPressComments, disqus } = useThemeOptions()
+
+  if (typeof window === 'undefined') {
+    return null
+  }
+
   return (
-    <>
+    <Suspense fallback={<></>}>
       {!!addWordPressComments && post.commentStatus === 'open' && (
         <WordPressComments post={post} />
       )}
       {!!disqus && <DisqusComments disqus={disqus} post={post} />}
-    </>
+    </Suspense>
   )
 }

--- a/packages/gatsby-theme-wp-starter/src/components/comments/Comments.js
+++ b/packages/gatsby-theme-wp-starter/src/components/comments/Comments.js
@@ -1,16 +1,26 @@
-import React from 'react'
+import React, { Suspense } from 'react'
 import { useThemeOptions } from '@gatsbywpthemes/gatsby-theme-blog-data/src/hooks'
-import { WordPressComments, DisqusComments } from 'starterComponents'
+import { WordPressComments } from 'starterComponents'
+
+const DisqusComments = React.lazy(() =>
+  import(
+    /* webpackChunkName: "DisqusComments", webpackExports: ["DisqusComments"] */ 'bootstrap5ThemeComponents'
+  ).then((mod) => ({ default: mod.DisqusComments }))
+)
 
 export const Comments = ({ post }) => {
   const { addWordPressComments, disqus } = useThemeOptions()
 
+  if (typeof window === 'undefined') {
+    return null
+  }
+
   return (
-    <>
+    <Suspense fallback={<></>}>
       {!!addWordPressComments && post.commentStatus === 'open' && (
         <WordPressComments post={post} />
       )}
       {!!disqus && <DisqusComments disqus={disqus} post={post} />}
-    </>
+    </Suspense>
   )
 }


### PR DESCRIPTION
Lazyload everything you can, everything that's not part of the first render should be lazy-loaded.

You don't see much impact because of the `export * from '..'` issue. It will improve when Gatsby 3.0.0 comes out. If you want to negate this, I recommend importing directly instead of having an index.js in between.